### PR TITLE
refactor CPU feature detection via ifunc & override

### DIFF
--- a/bench/chia_bench.cpp
+++ b/bench/chia_bench.cpp
@@ -172,7 +172,6 @@ void benchFastAggregateVerification() {
 
 int main(int argc, char* argv[])
 {
-    init();
     benchSigs();
     benchVerification();
     benchBatchVerification();

--- a/bench/eth_bench.cpp
+++ b/bench/eth_bench.cpp
@@ -163,7 +163,6 @@ void benchPairing() {
 
 int main(int argc, char* argv[])
 {
-    init();
     benchG1Add();
     benchG1Mul();
     benchG2Add();

--- a/include/bls12-381/arithmetic.hpp
+++ b/include/bls12-381/arithmetic.hpp
@@ -24,16 +24,12 @@ void _lsubAssign(fp* z, const fp* x);
 void _neg(fp* z, const fp* x);
 void _square(fp* z, const fp* x);
 
-#if defined(__x86_64__)
-void __mul(fp* z, const fp* x, const fp* y);
-void __mul_ex(fp* z, const fp* x, const fp* y);
-    #if defined(__ADX__) && defined(__BMI2__)
-    void _mul(fp* z, const fp* x, const fp* y);
-    #else
-    extern void (*_mul)(fp*, const fp*, const fp*);
-    #endif
+#if defined(__x86_64__) && defined(__ELF__)
+extern void _mul(fp*, const fp*, const fp*);
+#elif defined(__x86_64__)
+extern void (*_mul)(fp*, const fp*, const fp*);
 #else
-void _mul(fp* z, const fp* x, const fp* y);
+void _mul(fp*, const fp*, const fp*);
 #endif
 
 // Add64 returns the sum with carry of x, y and carry: sum = x + y + carry.

--- a/src/arithmetic.cpp
+++ b/src/arithmetic.cpp
@@ -1782,8 +1782,7 @@ static bool cpu_has_bmi2_and_adx() {
 #ifdef __ELF__
 extern "C" char** _dl_argv;
 
-__attribute__((no_sanitize_address))
-extern "C" blsmul_func_t resolve_blsmul() {
+extern "C" blsmul_func_t __attribute__((no_sanitize_address)) resolve_blsmul() {
     int argc = *(int*)(_dl_argv - 1);
     char** my_environ = (char**)(_dl_argv + argc + 1);
     while(*my_environ != nullptr) {

--- a/src/arithmetic.cpp
+++ b/src/arithmetic.cpp
@@ -1782,6 +1782,7 @@ static bool cpu_has_bmi2_and_adx() {
 #ifdef __ELF__
 extern "C" char** _dl_argv;
 
+__attribute__((no_sanitize_address))
 extern "C" blsmul_func_t resolve_blsmul() {
     int argc = *(int*)(_dl_argv - 1);
     char** my_environ = (char**)(_dl_argv + argc + 1);

--- a/src/arithmetic.cpp
+++ b/src/arithmetic.cpp
@@ -8,43 +8,6 @@ using namespace std;
 namespace bls12_381
 {
 
-#if defined(__x86_64__) && (!defined(__ADX__) || !defined(__BMI2__))
-void (*_mul)(fp*, const fp*, const fp*) { &__mul };
-#endif
-
-void init(bool cpu_features)
-{
-    #if defined(__x86_64__) && (!defined(__ADX__) || !defined(__BMI2__))
-    // set default mul() function (without cpu features)
-    _mul = &__mul;
-
-    if(cpu_features)
-    {
-        // detect cpu features on this machine and set mul_ex() if ADX/BMI2 available
-        #if defined(__GNUC__) && __GNUC__ >= 11
-        __builtin_cpu_init();
-        if(__builtin_cpu_supports("bmi2") && __builtin_cpu_supports("adx"))
-        {
-            _mul = &__mul_ex;
-        }
-        #else
-        // borrowed from: https://github.com/Mysticial/FeatureDetector/blob/master/src/x86/cpu_x86.cpp
-        int32_t info[4];
-        __cpuid_count(0, 0, info[0], info[1], info[2], info[3]);
-        int nIds = info[0];
-        if(nIds >= 0x00000007)
-        {
-            __cpuid_count(0x00000007, 0, info[0], info[1], info[2], info[3]);
-            if((info[1] & (1 <<  8)) && (info[1] & (1 << 19))) // BMI2 && ADX
-            {
-                _mul = &__mul_ex;
-            }
-        }
-        #endif
-    }
-    #endif
-}
-
 #ifdef __x86_64__
 void _add(fp* z, const fp* x, const fp* y)
 {
@@ -763,12 +726,6 @@ void _neg(fp* z, const fp* x)
 #endif
 
 #ifdef __x86_64__
-#if defined(__ADX__) && defined(__BMI2__)
-void _mul(fp* z, const fp* x, const fp* y)
-{
-    __mul_ex(z, x, y);
-}
-#endif
 void __mul(fp* z, const fp* x, const fp* y)
 {
     // x86_64 calling convention (https://en.wikipedia.org/wiki/X86_calling_conventions#System_V_AMD64_ABI):
@@ -1806,6 +1763,52 @@ void __mul_ex(fp* z, const fp* x, const fp* y)
     asm("pop %r15;");
     asm("pop %rbp;");
 }
+
+typedef void (*blsmul_func_t)(fp*, const fp*, const fp*);
+
+static bool cpu_has_bmi2_and_adx() {
+    // borrowed from: https://github.com/Mysticial/FeatureDetector/blob/master/src/x86/cpu_x86.cpp
+    int32_t info[4];
+    __cpuid_count(0, 0, info[0], info[1], info[2], info[3]);
+    int nIds = info[0];
+    if(nIds >= 0x00000007) {
+        __cpuid_count(0x00000007, 0, info[0], info[1], info[2], info[3]);
+        if((info[1] & (1 <<  8)) && (info[1] & (1 << 19))) // BMI2 && ADX
+            return true;
+    }
+    return false;
+}
+
+#ifdef __ELF__
+extern "C" char** _dl_argv;
+
+extern "C" blsmul_func_t resolve_blsmul() {
+    int argc = *(int*)(_dl_argv - 1);
+    char** my_environ = (char**)(_dl_argv + argc + 1);
+    while(*my_environ != nullptr) {
+       const char disable_str[] = "BLS_DISABLE_BMI2";
+        if(strncmp(*my_environ++, disable_str, strlen(disable_str)) == 0)
+           return __mul;
+    }
+
+    if(cpu_has_bmi2_and_adx())
+       return __mul_ex;
+    return __mul;
+}
+
+void _mul(fp*, const fp*, const fp*) __attribute__((ifunc("resolve_blsmul")));
+#else
+blsmul_func_t _mul = __mul;
+
+struct bls_mul_init {
+   bls_mul_init() {
+      if(cpu_has_bmi2_and_adx())
+         _mul = __mul_ex;
+   }
+};
+static bls_mul_init the_bls_mul_init;
+
+#endif //__ELF__
 #else
 void _mul(fp* z, const fp* x, const fp* y)
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,3 +2,8 @@ add_executable(unittests unittests.cpp)
 target_link_libraries(unittests bls12-381)
 
 add_test(NAME bls12-381 COMMAND unittests)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  add_test(NAME bls12-381-nobmi2 COMMAND unittests)
+  set_tests_properties(bls12-381-nobmi2 PROPERTIES ENVIRONMENT "BLS_DISABLE_BMI2=1")
+endif()

--- a/test/unittests.cpp
+++ b/test/unittests.cpp
@@ -1756,8 +1756,6 @@ void TestExtraVectors()
 
 int main()
 {
-    init();
-
     TestScalar();
 
     TestFieldElementValidation();


### PR DESCRIPTION
This is a substantial modification to the BMI2 & ADX CPU feature detection. Now, on x86-64 Linux, the decision to use the BMI2+ADX path is performed in an IFUNC resolver. The benefit of this approach is that when built with typical hardening options `-Wl,-z,relro,-z,now` ([as Leap "pinned"/binary builds do](https://github.com/AntelopeIO/leap/blob/47d20a41ea500141600772758399005b8e664722/scripts/pinned_toolchain.cmake#L14)) the function pointer will be in read only memory after the linker finishes loading the executable.

The primary downside is that this is really a Linux only feature, so we need a fallback path for other platforms. A static class and function pointer is used in this case.

Additionally, for the x86-64 Linux path, there is a mechanism to override the detection and disable the BMI2+ADX path via an environment variable. This allows unit testing (or more) the non BMI2+ADX code path even on a CPU that has BMI2+ADX.