### PR TITLE
Update APIs to use `std::span` instead of `std::vector`. 

### DIFF
--- a/bench/chia_bench.cpp
+++ b/bench/chia_bench.cpp
@@ -22,15 +22,16 @@ void endStopwatch(string testName,
     auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
             end - start);
 
-    cout << endl << testName << endl;
+    cout << '\n' << testName << '\n';
     cout << "Total: " << numIters << " runs in " << now_ms.count()
-         << " ms" << endl;
+         << " ms" << '\n';
     cout << "Avg: " << now_ms.count() / static_cast<double>(numIters)
-         << " ms" << endl;
+         << " ms" << '\n';
 }
 
-std::vector<uint8_t> getRandomSeed() {
-    uint64_t buf[4];
+std::array<uint8_t, 32> getRandomSeed() {
+    std::array<uint8_t, 32> res;
+    uint64_t *buf = reinterpret_cast<uint64_t *>(res.data());
     std::random_device rd;
     std::mt19937_64 gen(rd());
     std::uniform_int_distribution<uint64_t> dis;
@@ -38,8 +39,7 @@ std::vector<uint8_t> getRandomSeed() {
     buf[1] = dis(gen);
     buf[2] = dis(gen);
     buf[3] = dis(gen);
-    vector<uint8_t> ret(buf, buf + 32);
-    return ret;
+    return res;
 }
 
 void IntToFourBytes(uint8_t* result,
@@ -52,7 +52,8 @@ void IntToFourBytes(uint8_t* result,
 void benchSigs() {
     string testName = "Signing";
     const int numIters = 5000;
-    array<uint64_t, 4> sk = secret_key(getRandomSeed());
+    auto seed = getRandomSeed();
+    array<uint64_t, 4> sk = secret_key(seed);
     array<uint8_t, 48UL> pk = public_key(sk).toCompressedBytesBE();
     vector<uint8_t> message1(pk.begin(), pk.end());
 
@@ -67,7 +68,8 @@ void benchSigs() {
 void benchVerification() {
     string testName = "Verification";
     const int numIters = 10000;
-    array<uint64_t, 4> sk = secret_key(getRandomSeed());
+    auto seed = getRandomSeed();
+    array<uint64_t, 4> sk = secret_key(seed);
     g1 pk = public_key(sk);
 
     std::vector<g2> sigs;
@@ -101,7 +103,8 @@ void benchBatchVerification() {
         uint8_t message[4];
         IntToFourBytes(message, i);
         vector<uint8_t> messageBytes(message, message + 4);
-        array<uint64_t, 4> sk = secret_key(getRandomSeed());
+        auto seed = getRandomSeed();
+        array<uint64_t, 4> sk = secret_key(seed);
         g1 pk = public_key(sk);
         sig_bytes.push_back(sign(sk, messageBytes).toCompressedBytesBE());
         pk_bytes.push_back(pk.toCompressedBytesBE());

--- a/bench/chia_bench.cpp
+++ b/bench/chia_bench.cpp
@@ -52,8 +52,7 @@ void IntToFourBytes(uint8_t* result,
 void benchSigs() {
     string testName = "Signing";
     const int numIters = 5000;
-    auto seed = getRandomSeed();
-    array<uint64_t, 4> sk = secret_key(seed);
+    array<uint64_t, 4> sk = secret_key(getRandomSeed());
     array<uint8_t, 48UL> pk = public_key(sk).toCompressedBytesBE();
     vector<uint8_t> message1(pk.begin(), pk.end());
 
@@ -68,8 +67,7 @@ void benchSigs() {
 void benchVerification() {
     string testName = "Verification";
     const int numIters = 10000;
-    auto seed = getRandomSeed();
-    array<uint64_t, 4> sk = secret_key(seed);
+    array<uint64_t, 4> sk = secret_key(getRandomSeed());
     g1 pk = public_key(sk);
 
     std::vector<g2> sigs;
@@ -103,8 +101,7 @@ void benchBatchVerification() {
         uint8_t message[4];
         IntToFourBytes(message, i);
         vector<uint8_t> messageBytes(message, message + 4);
-        auto seed = getRandomSeed();
-        array<uint64_t, 4> sk = secret_key(seed);
+        array<uint64_t, 4> sk = secret_key(getRandomSeed());
         g1 pk = public_key(sk);
         sig_bytes.push_back(sign(sk, messageBytes).toCompressedBytesBE());
         pk_bytes.push_back(pk.toCompressedBytesBE());

--- a/bench/chia_bench.cpp
+++ b/bench/chia_bench.cpp
@@ -54,12 +54,11 @@ void benchSigs() {
     const int numIters = 5000;
     array<uint64_t, 4> sk = secret_key(getRandomSeed());
     array<uint8_t, 48UL> pk = public_key(sk).toCompressedBytesBE();
-    vector<uint8_t> message1(pk.begin(), pk.end());
 
     auto start = startStopwatch();
 
     for (int i = 0; i < numIters; i++) {
-        sign(sk, message1);
+        sign(sk, pk);
     }
     endStopwatch(testName, start, numIters);
 }
@@ -75,16 +74,14 @@ void benchVerification() {
     for (int i = 0; i < numIters; i++) {
         uint8_t message[4];
         IntToFourBytes(message, i);
-        vector<uint8_t> messageBytes(message, message + 4);
-        sigs.push_back(sign(sk, messageBytes));
+        sigs.push_back(sign(sk, message));
     }
 
     auto start = startStopwatch();
     for (int i = 0; i < numIters; i++) {
         uint8_t message[4];
         IntToFourBytes(message, i);
-        vector<uint8_t> messageBytes(message, message + 4);
-        bool ok = verify(pk, messageBytes, sigs[i]);
+        bool ok = verify(pk, message, sigs[i]);
         if(!ok) throw std::invalid_argument("benchVerification: !ok");
     }
     endStopwatch(testName, start, numIters);

--- a/bench/chia_bench.cpp
+++ b/bench/chia_bench.cpp
@@ -30,8 +30,7 @@ void endStopwatch(string testName,
 }
 
 std::array<uint8_t, 32> getRandomSeed() {
-    std::array<uint8_t, 32> res;
-    uint64_t *buf = reinterpret_cast<uint64_t *>(res.data());
+    std::array<uint64_t, 4> buf;
     std::random_device rd;
     std::mt19937_64 gen(rd());
     std::uniform_int_distribution<uint64_t> dis;
@@ -39,6 +38,8 @@ std::array<uint8_t, 32> getRandomSeed() {
     buf[1] = dis(gen);
     buf[2] = dis(gen);
     buf[3] = dis(gen);
+    std::array<uint8_t, 32> res;
+    memcpy(res.data(), buf.data(), sizeof(res));
     return res;
 }
 

--- a/include/bls12-381/g.hpp
+++ b/include/bls12-381/g.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <cmath>
-#include <vector>
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <span>

--- a/include/bls12-381/g.hpp
+++ b/include/bls12-381/g.hpp
@@ -60,7 +60,7 @@ public:
 
     auto operator<=>(const g1&) const = default;
    
-   static std::optional<g1> multiExp(std::span<const g1> points, std::span<const std::array<uint64_t, 4>> scalars, std::function<void()> yield = std::function<void()>());
+    static std::optional<g1> multiExp(std::span<const g1> points, std::span<const std::array<uint64_t, 4>> scalars, std::function<void()> yield = std::function<void()>());
     static g1 mapToCurve(const fp& e);
     static std::tuple<fp, fp> swuMapG1(const fp& e);
     static void isogenyMapG1(fp& x, fp& y);

--- a/include/bls12-381/g.hpp
+++ b/include/bls12-381/g.hpp
@@ -60,7 +60,7 @@ public:
 
     auto operator<=>(const g1&) const = default;
    
-    static std::optional<g1> multiExp(const std::vector<g1>& points, const std::vector<std::array<uint64_t, 4>>& scalars, std::function<void()> yield = std::function<void()>());
+   static std::optional<g1> multiExp(std::span<const g1> points, std::span<const std::array<uint64_t, 4>> scalars, std::function<void()> yield = std::function<void()>());
     static g1 mapToCurve(const fp& e);
     static std::tuple<fp, fp> swuMapG1(const fp& e);
     static void isogenyMapG1(fp& x, fp& y);
@@ -117,7 +117,7 @@ public:
 
     auto operator<=>(const g2&) const = default;
    
-    static std::optional<g2> multiExp(const std::vector<g2>& points, const std::vector<std::array<uint64_t, 4>>& scalars, std::function<void()> yield = std::function<void()>());
+    static std::optional<g2> multiExp(std::span<const g2> points, std::span<const std::array<uint64_t, 4>> scalars, std::function<void()> yield = std::function<void()>());
     static g2 mapToCurve(const fp2& e);
     static std::tuple<fp2, fp2> swuMapG2(const fp2& e);
     //static void isogenyMapG2(fp2& x, fp2& y);

--- a/include/bls12-381/pairing.hpp
+++ b/include/bls12-381/pairing.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <array>
 #include <vector>
+#include <span>
 #include <functional>
 
 namespace bls12_381
@@ -18,9 +19,9 @@ namespace pairing
     void doubling_step(std::array<fp2, 3>& coeff, g2& r);
     void addition_step(std::array<fp2, 3>& coeff, g2& r, g2& tp);
     void pre_compute(std::array<std::array<fp2, 3>, 68>& ellCoeffs, g2& twistPoint);
-    fp12 miller_loop(std::vector<std::tuple<g1, g2>>& pairs, std::function<void()> yield);
+    fp12 miller_loop(std::span<const std::tuple<g1, g2>> pairs, std::function<void()> yield);
     void final_exponentiation(fp12& f);
-    fp12 calculate(std::vector<std::tuple<g1, g2>>& pairs, std::function<void()> yield = std::function<void()>());
+    fp12 calculate(std::span<const std::tuple<g1, g2>> pairs, std::function<void()> yield = std::function<void()>());
     void add_pair(std::vector<std::tuple<g1, g2>>& pairs, const g1& e1, const g2& e2);
 } // namespace pairing
 

--- a/include/bls12-381/scalar.hpp
+++ b/include/bls12-381/scalar.hpp
@@ -6,6 +6,7 @@
 #include <span>
 #include <stdexcept>
 #include <bit>
+#include <string_view>
 
 #include <bls12-381/fp.hpp>
 #include <bls12-381/g.hpp>
@@ -374,7 +375,7 @@ std::string bytesToHex(const std::span<const uint8_t, N>& in)
     }
     return s;
 }
-std::string bytesToHex(const std::vector<uint8_t>& in);
+std::string bytesToHex(std::span<const uint8_t> in);
 
 template<size_t N>
 void hexToBytes(const std::string& s, std::span<uint8_t, N> out)
@@ -398,6 +399,6 @@ std::array<uint8_t, N> hexToBytes(const std::string& s)
     hexToBytes<N>(s, out);
     return out;
 }
-std::vector<uint8_t> hexToBytes(const std::string& s);
+std::vector<uint8_t> hexToBytes(std::string_view s);
 
 } // namespace bls12_381

--- a/include/bls12-381/signatures.hpp
+++ b/include/bls12-381/signatures.hpp
@@ -145,19 +145,25 @@ bool aggregate_verify(
     const bool checkForDuplicateMessages = false
 );
 
-template<class T, class F>
-g1 aggregate_public_keys(std::span<const T> pks, F &&f) {
+// f is an accessor function in case we have a vector of object containing public keys
+// pred can be use to aggregate public keys specified in a bit mask for example
+template<class T, class F, class PRED>
+g1 aggregate_public_keys(std::span<const T> pks, F &&f, PRED &&pred) {
     g1 agg_pk = g1({fp::zero(), fp::zero(), fp::zero()});
-    for(const auto& t : pks)
-        agg_pk = agg_pk.add(std::forward<F>(f)(t));
+    for (size_t i=0; i<pks.size(); ++i)
+        if (std::forward<PRED>(pred)(pks[i], i))
+            agg_pk = agg_pk.add(std::forward<F>(f)(pks[i]));
     return agg_pk;
 }
 
-template<class T, class F>
-g2 aggregate_signatures(std::span<const T> sigs, F &&f) {
+// f is an accessor function in case we have a vector of object containing signatures
+// pred can be use to aggregate signatures specified in a bit mask for example
+template<class T, class F, class PRED>
+g2 aggregate_signatures(std::span<const T> sigs, F &&f, PRED &&pred) {
     g2 agg_sig = g2({fp2::zero(), fp2::zero(), fp2::zero()});
-    for(const auto& t : sigs)
-        agg_sig = agg_sig.add(std::forward<F>(f)(t));
+    for (size_t i=0; i<sigs.size(); ++i)
+        if (std::forward<PRED>(pred)(sigs[i], i))
+            agg_sig = agg_sig.add(std::forward<F>(f)(sigs[i]));
     return agg_sig;
 }
 

--- a/include/bls12-381/signatures.hpp
+++ b/include/bls12-381/signatures.hpp
@@ -145,10 +145,11 @@ bool aggregate_verify(
     const bool checkForDuplicateMessages = false
 );
 
-// f is an accessor function in case we have a span of objects of type T containing public keys
-// pred can be use to aggregate public keys specified in a bit mask for example
-template<class T, class F, class PRED>
-g1 aggregate_public_keys(std::span<const T> pks, F &&f, PRED &&pred) {
+// `f` is an accessor function in case we have a span of objects of type T containing public keys: `g1 f(const T&)`
+// `pred` can be used to aggregate public keys specified in a bit mask for example: `bool pred(const T&, size_t)`
+template<class T, class F, class PRED = decltype([](const T&, size_t){return true;})>
+inline auto aggregate_public_keys(std::span<T> pks, F&& f, PRED&& pred = PRED())
+    -> decltype(f(*pks.data()), pred(*pks.data(), 0), g1()) {
     g1 agg_pk = g1({fp::zero(), fp::zero(), fp::zero()});
     for (size_t i=0; i<pks.size(); ++i)
         if (std::forward<PRED>(pred)(pks[i], i))
@@ -156,10 +157,11 @@ g1 aggregate_public_keys(std::span<const T> pks, F &&f, PRED &&pred) {
     return agg_pk;
 }
 
-// f is an accessor function in case we have a span of objects of type T containing signatures
-// pred can be use to aggregate signatures specified in a bit mask for example
-template<class T, class F, class PRED>
-g2 aggregate_signatures(std::span<const T> sigs, F &&f, PRED &&pred) {
+// f is an accessor function in case we have a span of objects of type T containing signatures: `g2 f(const T&)`
+// pred can be used to aggregate signatures specified in a bit mask for example: `bool pred(const T&, size_t)`
+template<class T, class F, class PRED = decltype([](const T&, size_t){return true;})>
+inline auto aggregate_signatures(std::span<T> sigs, F&& f, PRED&& pred = PRED()) 
+    -> decltype(f(*sigs.data()), pred(*sigs.data(), 0), g2()) {
     g2 agg_sig = g2({fp2::zero(), fp2::zero(), fp2::zero()});
     for (size_t i=0; i<sigs.size(); ++i)
         if (std::forward<PRED>(pred)(sigs[i], i))

--- a/include/bls12-381/signatures.hpp
+++ b/include/bls12-381/signatures.hpp
@@ -1,6 +1,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <array>
+#include <span>
 #include <vector>
 #include <string>
 
@@ -100,7 +101,7 @@ g2 derive_child_g2_unhardened(
 );
 
 // Implements secret key derivation based on HKDF Mod R as specified in EIP 2333: https://eips.ethereum.org/EIPS/eip-2333#hkdf_mod_r
-std::array<uint64_t, 4> secret_key(const std::vector<uint8_t>& seed);
+std::array<uint64_t, 4> secret_key(std::span<const uint8_t> seed);
 
 // Derive public key from a BLS private key
 g1 public_key(const std::array<uint64_t, 4>& sk);

--- a/include/bls12-381/signatures.hpp
+++ b/include/bls12-381/signatures.hpp
@@ -134,12 +134,12 @@ g1 aggregate_public_keys(std::span<const g1> pks);
 g2 aggregate_signatures(std::span<const g2> sigs);
 
 // Aggregate verify using a set of public keys, a set of messages and an aggregated signature
-// the boolean parameter enables an additional check for dublicate messages (possible attack
-// std::vector: see page 6 of https://crypto.stanford.edu/~dabo/pubs/papers/aggreg.pdf, "A potential
+// the boolean parameter enables an additional check for duplicate messages (possible attack
+// vector: see page 6 of https://crypto.stanford.edu/~dabo/pubs/papers/aggreg.pdf, "A potential
 // attack on aggregate signatures.")
 bool aggregate_verify(
     std::span<const g1> pubkeys,
-    const std::vector<std::vector<uint8_t>> &messages,
+    std::span<const std::vector<uint8_t>> messages,
     const g2& signature,
     const bool checkForDuplicateMessages = false
 );

--- a/include/bls12-381/signatures.hpp
+++ b/include/bls12-381/signatures.hpp
@@ -4,9 +4,10 @@
 #include <span>
 #include <vector>
 #include <string>
+#include <bls12-381/g.hpp>
+#include <bls12-381/fp.hpp>
 
-namespace bls12_381
-{
+namespace bls12_381 {
 
 class g1;
 class g2;
@@ -143,6 +144,22 @@ bool aggregate_verify(
     const g2& signature,
     const bool checkForDuplicateMessages = false
 );
+
+template<class T, class F>
+g1 aggregate_public_keys(std::span<const T> pks, F &&f) {
+    g1 agg_pk = g1({fp::zero(), fp::zero(), fp::zero()});
+    for(const auto& t : pks)
+        agg_pk = agg_pk.add(std::forward<F>(f)(t));
+    return agg_pk;
+}
+
+template<class T, class F>
+g2 aggregate_signatures(std::span<const T> sigs, F &&f) {
+    g2 agg_sig = g2({fp2::zero(), fp2::zero(), fp2::zero()});
+    for(const auto& t : sigs)
+        agg_sig = agg_sig.add(std::forward<F>(f)(t));
+    return agg_sig;
+}
 
 // Create new BLS private key from bytes. Enable modulo division to ensure scalar is element of the field
 std::array<uint64_t, 4> sk_from_bytes(

--- a/include/bls12-381/signatures.hpp
+++ b/include/bls12-381/signatures.hpp
@@ -107,38 +107,38 @@ std::array<uint64_t, 4> secret_key(std::span<const uint8_t> seed);
 g1 public_key(const std::array<uint64_t, 4>& sk);
 
 g2 fromMessage(
-    const std::vector<uint8_t>& msg,
+    std::span<const uint8_t> msg,
     const std::string& dst
 );
 
 // Sign message with a private key
 g2 sign(
     const std::array<uint64_t, 4>& sk,
-    const std::vector<uint8_t>& msg
+    std::span<const uint8_t> msg
 );
 
 // Verify signature of a message using a public key
 bool verify(
     const g1& pubkey,
-    const std::vector<uint8_t>& message,
+    std::span<const uint8_t> message,
     const g2& signature
 );
 
 // Aggregate private keys
-std::array<uint64_t, 4> aggregate_secret_keys(const std::vector<std::array<uint64_t, 4>>& sks);
+std::array<uint64_t, 4> aggregate_secret_keys(std::span<const std::array<uint64_t, 4>> sks);
 
 // Aggregate public keys
-g1 aggregate_public_keys(const std::vector<g1>& pks);
+g1 aggregate_public_keys(std::span<const g1> pks);
 
 // Aggregate signatures
-g2 aggregate_signatures(const std::vector<g2>& sigs);
+g2 aggregate_signatures(std::span<const g2> sigs);
 
 // Aggregate verify using a set of public keys, a set of messages and an aggregated signature
 // the boolean parameter enables an additional check for dublicate messages (possible attack
 // std::vector: see page 6 of https://crypto.stanford.edu/~dabo/pubs/papers/aggreg.pdf, "A potential
 // attack on aggregate signatures.")
 bool aggregate_verify(
-    const std::vector<g1>& pubkeys,
+    std::span<const g1> pubkeys,
     const std::vector<std::vector<uint8_t>> &messages,
     const g2& signature,
     const bool checkForDuplicateMessages = false
@@ -162,8 +162,8 @@ bool pop_verify(
 );
 
 bool pop_fast_aggregate_verify(
-    const std::vector<g1>& pubkeys,
-    const std::vector<uint8_t>& message,
+    std::span<const g1> pubkeys,
+    std::span<const uint8_t> message,
     const g2& signature
 );
 

--- a/include/bls12-381/signatures.hpp
+++ b/include/bls12-381/signatures.hpp
@@ -145,7 +145,7 @@ bool aggregate_verify(
     const bool checkForDuplicateMessages = false
 );
 
-// f is an accessor function in case we have a vector of object containing public keys
+// f is an accessor function in case we have a span of objects of type T containing public keys
 // pred can be use to aggregate public keys specified in a bit mask for example
 template<class T, class F, class PRED>
 g1 aggregate_public_keys(std::span<const T> pks, F &&f, PRED &&pred) {
@@ -156,7 +156,7 @@ g1 aggregate_public_keys(std::span<const T> pks, F &&f, PRED &&pred) {
     return agg_pk;
 }
 
-// f is an accessor function in case we have a vector of object containing signatures
+// f is an accessor function in case we have a span of objects of type T containing signatures
 // pred can be use to aggregate signatures specified in a bit mask for example
 template<class T, class F, class PRED>
 g2 aggregate_signatures(std::span<const T> sigs, F &&f, PRED &&pred) {

--- a/src/g.cpp
+++ b/src/g.cpp
@@ -439,7 +439,7 @@ g1 g1::glvEndomorphism() const
 // MultiExp calculates multi exponentiation. Given pairs of G1 point and scalar values
 // (P_0, e_0), (P_1, e_1), ... (P_n, e_n) calculates r = e_0 * P_0 + e_1 * P_1 + ... + e_n * P_n
 // Length of points and scalars are expected to be equal, otherwise NONE is returned.
-optional<g1> g1::multiExp(const vector<g1>& points, const vector<array<uint64_t, 4>>& scalars, std::function<void()> yield)
+optional<g1> g1::multiExp(std::span<const g1> points, std::span<const array<uint64_t, 4>> scalars, std::function<void()> yield)
 {
     if(points.size() != scalars.size())
     {
@@ -1167,7 +1167,7 @@ g2 g2::frobeniusMap(int64_t power) const
 // MultiExp calculates multi exponentiation. Given pairs of G2 point and scalar values
 // (P_0, e_0), (P_1, e_1), ... (P_n, e_n) calculates r = e_0 * P_0 + e_1 * P_1 + ... + e_n * P_n
 // Length of points and scalars are expected to be equal, otherwise NONE is returned.
-optional<g2> g2::multiExp(const vector<g2>& points, const vector<array<uint64_t, 4>>& scalars, std::function<void()> yield)
+optional<g2> g2::multiExp(std::span<const g2> points, std::span<const std::array<uint64_t, 4>> scalars, std::function<void()> yield)
 {
     if(points.size() != scalars.size())
     {

--- a/src/pairing.cpp
+++ b/src/pairing.cpp
@@ -41,7 +41,7 @@ void doubling_step(array<fp2, 3>& coeff, g2& r)
     coeff[2] = t[6].neg();
 }
 
-void addition_step(array<fp2, 3>& coeff, g2& r, g2& tp)
+void addition_step(array<fp2, 3>& coeff, g2& r, const g2& tp)
 {
     // Algorithm 12 in https://eprint.iacr.org/2010/526.pdf
     fp2 t[10];
@@ -72,7 +72,7 @@ void addition_step(array<fp2, 3>& coeff, g2& r, g2& tp)
     coeff[2] = t[1];
 }
 
-void pre_compute(array<array<fp2, 3>, 68>& ellCoeffs, g2& twistPoint)
+void pre_compute(array<array<fp2, 3>, 68>& ellCoeffs, const g2& twistPoint)
 {
     // Algorithm 5 in  https://eprint.iacr.org/2019/077.pdf
     if(twistPoint.isZero())
@@ -93,7 +93,7 @@ void pre_compute(array<array<fp2, 3>, 68>& ellCoeffs, g2& twistPoint)
     }
 }
 
-fp12 miller_loop(vector<tuple<g1, g2>>& pairs, std::function<void()> yield)
+fp12 miller_loop(std::span<const std::tuple<g1, g2>> pairs, std::function<void()> yield)
 {
     vector<array<array<fp2, 3>, 68>> ellCoeffs;
     ellCoeffs.resize(pairs.size());
@@ -177,7 +177,7 @@ void final_exponentiation(fp12& f)
     f = t[3].mul(t[4]);
 }
 
-fp12 calculate(vector<tuple<g1, g2>>& pairs, std::function<void()> yield)
+fp12 calculate(std::span<const std::tuple<g1, g2>> pairs, std::function<void()> yield)
 {
     fp12 f = fp12::one();
     if(pairs.size() == 0)
@@ -193,10 +193,7 @@ void add_pair(vector<tuple<g1, g2>>& pairs, const g1& e1, const g2& e2)
 {
     if(!(e1.isZero() || e2.isZero()))
     {
-        pairs.push_back({
-            e1.affine(),
-            e2.affine()
-        });
+        pairs.emplace_back(e1.affine(), e2.affine());
     }
 }
 

--- a/src/pairing.cpp
+++ b/src/pairing.cpp
@@ -180,7 +180,7 @@ void final_exponentiation(fp12& f)
 fp12 calculate(std::span<const std::tuple<g1, g2>> pairs, std::function<void()> yield)
 {
     fp12 f = fp12::one();
-    if(pairs.size() == 0)
+    if(pairs.empty())
     {
         return f;
     }

--- a/src/scalar.cpp
+++ b/src/scalar.cpp
@@ -5,7 +5,7 @@ using namespace std;
 namespace bls12_381
 {
 
-   vector<uint8_t> hexToBytes(std::string_view s)
+vector<uint8_t> hexToBytes(std::string_view s)
 {
     uint64_t start_idx = 0;
     if(s[0] == '0' && s[1] == 'x')
@@ -16,7 +16,7 @@ namespace bls12_381
     if(s.length() % 2 != 0)
     {
         // string length invalid!
-        return vector<uint8_t>();
+        return {};
     }
 
     vector<uint8_t> bytes;

--- a/src/scalar.cpp
+++ b/src/scalar.cpp
@@ -5,7 +5,7 @@ using namespace std;
 namespace bls12_381
 {
 
-vector<uint8_t> hexToBytes(const string& s)
+   vector<uint8_t> hexToBytes(std::string_view s)
 {
     uint64_t start_idx = 0;
     if(s[0] == '0' && s[1] == 'x')
@@ -30,7 +30,7 @@ vector<uint8_t> hexToBytes(const string& s)
     return bytes;
 }
 
-string bytesToHex(const vector<uint8_t>& in)
+string bytesToHex(std::span<const uint8_t> in)
 {
     constexpr char hexmap[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
     string s(2 + in.size() * 2, ' ');

--- a/src/signatures.cpp
+++ b/src/signatures.cpp
@@ -163,7 +163,7 @@ int hkdf256_extract_expand(
     return hkdf256_expand(output, outputLen, prk.data(), info, infoLen);
 }
 
-array<uint64_t, 4> secret_key(const vector<uint8_t>& seed)
+array<uint64_t, 4> secret_key(std::span<const uint8_t> seed)
 {
     // KeyGen
     // 1. PRK = HKDF-Extract("BLS-SIG-KEYGEN-SALT-", IKM || I2OSP(0, 1))

--- a/src/signatures.cpp
+++ b/src/signatures.cpp
@@ -581,7 +581,7 @@ g2 aggregate_signatures(std::span<const g2> sigs)
 
 bool aggregate_verify(
     std::span<const g1> pubkeys,
-    const vector<vector<uint8_t>> &messages,
+    std::span<const std::vector<uint8_t>> messages,
     const g2& signature,
     const bool checkForDuplicateMessages
 )

--- a/src/signatures.cpp
+++ b/src/signatures.cpp
@@ -325,7 +325,7 @@ array<uint64_t, 4> derive_child_sk_unhardened(
     sha.update(buf.data(), 48 + 4);
     sha.digest(digest.data());
 
-    array<uint64_t, 4> ret = aggregate_secret_keys({parentSk, sk_from_bytes(digest, true)});
+    array<uint64_t, 4> ret = aggregate_secret_keys(std::array{parentSk, sk_from_bytes(digest, true)});
     return ret;
 }
 
@@ -381,7 +381,7 @@ g2 derive_child_g2_unhardened(
     return pk.add(g2::one().mulScalar(remainder));
 }
 
-array<uint64_t, 4> aggregate_secret_keys(const vector<array<uint64_t, 4>>& sks)
+array<uint64_t, 4> aggregate_secret_keys(std::span<const std::array<uint64_t, 4>> sks)
 {
     if(sks.empty())
     {
@@ -495,7 +495,7 @@ int xmd_sh256(
 
 
 g2 fromMessage(
-    const vector<uint8_t>& msg,
+    std::span<const uint8_t> msg,
     const string& dst
 )
 {
@@ -528,7 +528,7 @@ g2 fromMessage(
 
 g2 sign(
     const array<uint64_t, 4>& sk,
-    const vector<uint8_t>& msg
+    std::span<const uint8_t> msg
 )
 {
     g2 p = fromMessage(msg, CIPHERSUITE_ID);
@@ -537,7 +537,7 @@ g2 sign(
 
 bool verify(
     const g1& pubkey,
-    const vector<uint8_t>& message,
+    std::span<const uint8_t> message,
     const g2& signature
 )
 {
@@ -559,7 +559,7 @@ bool verify(
     return fp12::one().equal(pairing::calculate(v));
 }
 
-g1 aggregate_public_keys(const vector<g1>& pks)
+g1 aggregate_public_keys(std::span<const g1> pks)
 {
     g1 agg_pk = g1({fp::zero(), fp::zero(), fp::zero()});
     for(const g1& pk : pks)
@@ -569,7 +569,7 @@ g1 aggregate_public_keys(const vector<g1>& pks)
     return agg_pk;
 }
 
-g2 aggregate_signatures(const vector<g2>& sigs)
+g2 aggregate_signatures(std::span<const g2> sigs)
 {
     g2 agg_sig = g2({fp2::zero(), fp2::zero(), fp2::zero()});
     for(const g2& sig : sigs)
@@ -580,7 +580,7 @@ g2 aggregate_signatures(const vector<g2>& sigs)
 }
 
 bool aggregate_verify(
-    const vector<g1>& pubkeys,
+    std::span<const g1> pubkeys,
     const vector<vector<uint8_t>> &messages,
     const g2& signature,
     const bool checkForDuplicateMessages
@@ -661,8 +661,8 @@ bool pop_verify(
 }
 
 bool pop_fast_aggregate_verify(
-    const vector<g1>& pubkeys,
-    const vector<uint8_t>& message,
+    std::span<const g1> pubkeys,
+    std::span<const uint8_t> message,
     const g2& signature
 )
 {

--- a/test/unittests.cpp
+++ b/test/unittests.cpp
@@ -1368,8 +1368,8 @@ void TestChiaVectors()
         throw invalid_argument("sig2 verification failed");
     }
 
-    g2 aggSig1 = aggregate_signatures({sig1, sig2});
-    if(!aggregate_verify({pk1, pk2}, {message1, message2}, aggSig1))
+    g2 aggSig1 = aggregate_signatures(std::array{sig1, sig2});
+    if(!aggregate_verify(std::array{pk1, pk2}, {message1, message2}, aggSig1))
     {
         throw invalid_argument("aggSig1 verification failed");
     }
@@ -1382,9 +1382,9 @@ void TestChiaVectors()
     g2 sig4 = sign(sk1, message4);
     g2 sig5 = sign(sk2, message5);
 
-    g2 aggSig2 = aggregate_signatures({sig3, sig4, sig5});
-
-    if(!aggregate_verify({pk1, pk1, pk2}, vector<vector<uint8_t>>{message3, message4, message5}, aggSig2))
+    g2 aggSig2 = aggregate_signatures(std::array{sig3, sig4, sig5});
+    
+    if(!aggregate_verify(std::array{pk1, pk1, pk2}, vector<vector<uint8_t>>{message3, message4, message5}, aggSig2))
     {
         throw invalid_argument("aggSig2 verification failed");
     }
@@ -1414,11 +1414,12 @@ void TestChiaVectors2()
     g2 sig6 = sign(sk1, message4);
 
 
-    g2 aggSigL = aggregate_signatures({sig1, sig2});
-    g2 aggSigR = aggregate_signatures({sig3, sig4, sig5});
-    g2 aggSig = aggregate_signatures({aggSigL, aggSigR, sig6});
+    g2 aggSigL = aggregate_signatures(std::array{sig1, sig2});
+    g2 aggSigR = aggregate_signatures(std::array{sig3, sig4, sig5});
+    g2 aggSig  = aggregate_signatures(std::array{aggSigL, aggSigR, sig6});
 
-    if(!aggregate_verify({pk1, pk2, pk2, pk1, pk1, pk1}, vector<vector<uint8_t>>{message1, message2, message1, message3, message1, message4}, aggSig))
+    if(!aggregate_verify(std::array{pk1, pk2, pk2, pk1, pk1, pk1},
+                         vector<vector<uint8_t>>{message1, message2, message1, message3, message1, message4}, aggSig))
     {
         throw invalid_argument("aggregate verify error");
     }
@@ -1515,8 +1516,8 @@ void TestSignatures()
         g2 sig1 = sign(sk1, message);
         g2 sig2 = sign(sk2, message);
 
-        g2 aggSig = aggregate_signatures({sig1, sig2});
-        if(aggregate_verify({pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSig, true))
+        g2 aggSig = aggregate_signatures(std::array{sig1, sig2});
+        if(aggregate_verify(std::array{pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSig, true))
         {
             throw invalid_argument("Should not verify aggregate with same message under BasicScheme");
         }
@@ -1545,8 +1546,8 @@ void TestAugScheme()
     augMsg2.insert(augMsg2.end(), pk2_bytes.begin(), pk2_bytes.end());
     g2 sig1Aug = sign(sk1, augMsg1);
     g2 sig2Aug = sign(sk2, augMsg2);
-    g2 aggSigAug = aggregate_signatures({sig1Aug, sig2Aug});
-    if(!aggregate_verify({pk1, pk2}, vector<vector<uint8_t>>{augMsg1, augMsg2}, aggSigAug, true))
+    g2 aggSigAug = aggregate_signatures(std::array{sig1Aug, sig2Aug});
+    if(!aggregate_verify(std::array{pk1, pk2}, vector<vector<uint8_t>>{augMsg1, augMsg2}, aggSigAug, true))
     {
         throw invalid_argument("Should verify aggregate with same message under AugScheme");
     }
@@ -1564,8 +1565,8 @@ void TestAggregateSKs()
     const array<uint64_t, 4> sk2 = secret_key(seed2);
     const g1 pk2 = public_key(sk2);
 
-    const array<uint64_t, 4> aggSk = aggregate_secret_keys({sk1, sk2});
-    const array<uint64_t, 4> aggSkAlt = aggregate_secret_keys({sk2, sk1});
+    const array<uint64_t, 4> aggSk = aggregate_secret_keys(std::array{sk1, sk2});
+    const array<uint64_t, 4> aggSkAlt = aggregate_secret_keys(std::array{sk2, sk1});
     if(aggSk != aggSkAlt) throw invalid_argument("aggSk != aggSkAlt");
 
     const g1 aggPubKey = pk1.add(pk2);
@@ -1577,7 +1578,7 @@ void TestAggregateSKs()
     const g2 aggSig2 = sign(aggSk, message);
 
 
-    const g2 aggSig = aggregate_signatures({sig1, sig2});
+    const g2 aggSig = aggregate_signatures(std::array{sig1, sig2});
     if(!aggSig.equal(aggSig2)) throw invalid_argument("aggSig != aggSig2");
 
     // Verify as a single G2Element
@@ -1585,20 +1586,20 @@ void TestAggregateSKs()
     if(!verify(aggPubKey, message, aggSig2)) throw invalid_argument("aggSig2 verify failed");
 
     // Verify aggregate with both keys (Fails since not distinct)
-    if(aggregate_verify({pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSig, true)) throw invalid_argument("aggregate verify of aggSig must fail");
-    if(aggregate_verify({pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSig2, true)) throw invalid_argument("aggregate verify of aggSig2 must fail");
+    if(aggregate_verify(std::array{pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSig, true)) throw invalid_argument("aggregate verify of aggSig must fail");
+    if(aggregate_verify(std::array{pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSig2, true)) throw invalid_argument("aggregate verify of aggSig2 must fail");
 
     // Try the same with distinct message, and same sk
     vector<uint8_t> message2 = {200, 29, 54, 8, 9, 29, 155, 55};
     g2 sig3 = sign(sk2, message2);
-    g2 aggSigFinal = aggregate_signatures({aggSig, sig3});
-    g2 aggSigAlt = aggregate_signatures({sig1, sig2, sig3});
-    g2 aggSigAlt2 = aggregate_signatures({sig1, sig3, sig2});
+    g2 aggSigFinal = aggregate_signatures(std::array{aggSig, sig3});
+    g2 aggSigAlt = aggregate_signatures(std::array{sig1, sig2, sig3});
+    g2 aggSigAlt2 = aggregate_signatures(std::array{sig1, sig3, sig2});
     if(!aggSigFinal.equal(aggSigAlt)) throw invalid_argument("aggSigFinal != aggSigAlt");
     if(!aggSigFinal.equal(aggSigAlt2)) throw invalid_argument("aggSigFinal != aggSigAlt2");
 
-    array<uint64_t, 4> skFinal = aggregate_secret_keys({aggSk, sk2});
-    array<uint64_t, 4> skFinalAlt = aggregate_secret_keys({sk2, sk1, sk2});
+    array<uint64_t, 4> skFinal = aggregate_secret_keys(std::array{aggSk, sk2});
+    array<uint64_t, 4> skFinalAlt = aggregate_secret_keys(std::array{sk2, sk1, sk2});
     if(skFinal != skFinalAlt) throw invalid_argument("skFinal != skFinalAlt");
     if(skFinal == aggSk) throw invalid_argument("skFinal == aggSk");
 
@@ -1608,7 +1609,7 @@ void TestAggregateSKs()
     if(pkFinal.equal(aggPubKey)) throw invalid_argument("pkFinal == aggPubKey");
 
     // Verify with aggPubKey (since we have multiple messages)
-    if(!aggregate_verify({aggPubKey, pk2}, vector<vector<uint8_t>>{message, message2}, aggSigFinal, true)) throw invalid_argument("verify with aggPubKey failed");
+    if(!aggregate_verify(std::array{aggPubKey, pk2}, vector<vector<uint8_t>>{message, message2}, aggSigFinal, true)) throw invalid_argument("verify with aggPubKey failed");
 }
 
 void TestPopScheme()
@@ -1637,8 +1638,8 @@ void TestPopScheme()
         // Wrong pk
         if(verify(pk2, msg1, sig1)) throw invalid_argument("must fail: wrong pk");
 
-        g2 aggsig = aggregate_signatures({sig1, sig2});
-        if(!aggregate_verify({pk1, pk2}, msgs, aggsig)) throw invalid_argument("aggregate_verify failed");
+        g2 aggsig = aggregate_signatures(std::array{sig1, sig2});
+        if(!aggregate_verify(std::array{pk1, pk2}, msgs, aggsig)) throw invalid_argument("aggregate_verify failed");
 
         // PopVerify
         g2 proof1 = pop_prove(sk1);
@@ -1647,8 +1648,8 @@ void TestPopScheme()
         // FastAggregateVerify
         // We want sk2 to sign the same message
         g2 sig2_same = sign(sk2, msg1);
-        g2 aggsig_same = aggregate_signatures({sig1, sig2_same});
-        if(!pop_fast_aggregate_verify({pk1, pk2}, msg1, aggsig_same)) throw invalid_argument("pop_fast_aggregate_verify failed");
+        g2 aggsig_same = aggregate_signatures(std::array{sig1, sig2_same});
+        if(!pop_fast_aggregate_verify(std::array{pk1, pk2}, msg1, aggsig_same)) throw invalid_argument("pop_fast_aggregate_verify failed");
     }
     {
         // from README:
@@ -1678,16 +1679,16 @@ void TestPopScheme()
         if(!pop_verify(pk1, pop1)) throw invalid_argument("pop_verify 1 failed");
         if(!pop_verify(pk2, pop2)) throw invalid_argument("pop_verify 2 failed");
         if(!pop_verify(pk3, pop3)) throw invalid_argument("pop_verify 3 failed");
-        g2 popSigAgg = aggregate_signatures({popSig1, popSig2, popSig3});
+        g2 popSigAgg = aggregate_signatures(std::array{popSig1, popSig2, popSig3});
 
-        if(!pop_fast_aggregate_verify({pk1, pk2, pk3}, message, popSigAgg)) throw invalid_argument("pop_fast_aggregate_verify failed");
+        if(!pop_fast_aggregate_verify(std::array{pk1, pk2, pk3}, message, popSigAgg)) throw invalid_argument("pop_fast_aggregate_verify failed");
 
         // Aggregate public key, indistinguishable from a single public key
         g1 popAggPk = pk1.add(pk2).add(pk3);
         if(!verify(popAggPk, message, popSigAgg)) throw invalid_argument("verify popSigAgg failed");
 
         // Aggregate private keys
-        array<uint64_t, 4> aggSk = aggregate_secret_keys({sk1, sk2, sk3});
+        array<uint64_t, 4> aggSk = aggregate_secret_keys(std::array{sk1, sk2, sk3});
         if(!sign(aggSk, message).equal(popSigAgg)) throw invalid_argument("sign(aggSk, message) != popSigAgg");
     }
 }

--- a/test/unittests.cpp
+++ b/test/unittests.cpp
@@ -1369,7 +1369,7 @@ void TestChiaVectors()
     }
 
     g2 aggSig1 = aggregate_signatures(std::array{sig1, sig2});
-    if(!aggregate_verify(std::array{pk1, pk2}, {message1, message2}, aggSig1))
+    if(!aggregate_verify(std::array{pk1, pk2}, std::array{message1, message2}, aggSig1))
     {
         throw invalid_argument("aggSig1 verification failed");
     }


### PR DESCRIPTION
Also:
- fix issue with `getRandomSeed`
- add versions for `aggregate` functions that take an accessor to avoid vector copies for each call.