### PR TITLE
don't return 0 exit code on failed tests

### DIFF
--- a/test/unittests.cpp
+++ b/test/unittests.cpp
@@ -1749,7 +1749,7 @@ void TestExtraVectors()
         catch (std::exception &e)
         {
             printf("test %d failed: %s \n", i, e.what());
-            continue;
+            throw;
         }
     }
 }


### PR DESCRIPTION
Just let the exception bubble out and abort the application so a failed test doesn't go unnoticed in automated test runs