### PR TITLE
Use length instead of subscript operator

### DIFF
--- a/src/fp.cpp
+++ b/src/fp.cpp
@@ -467,16 +467,16 @@ fp2::fp2(const fp2& e) : c0(e.c0), c1(e.c1)
 
 optional<fp2> fp2::fromBytesBE(const span<const uint8_t, 96> in, const conv_opt opt)
 {
-    optional<fp> c1 = fp::fromBytesBE(span<const uint8_t, 48>(&in[ 0], &in[48]), opt);
-    optional<fp> c0 = fp::fromBytesBE(span<const uint8_t, 48>(&in[48], &in[96]), opt);
+    optional<fp> c1 = fp::fromBytesBE(span<const uint8_t, 48>(&in[ 0], 48), opt);
+    optional<fp> c0 = fp::fromBytesBE(span<const uint8_t, 48>(&in[48], 48), opt);
     if(!c1 || !c0) return {};
     return fp2({*c0, *c1});
 }
 
 optional<fp2> fp2::fromBytesLE(const span<const uint8_t, 96> in, const conv_opt opt)
 {
-    optional<fp> c0 = fp::fromBytesLE(span<const uint8_t, 48>(&in[ 0], &in[48]), opt);
-    optional<fp> c1 = fp::fromBytesLE(span<const uint8_t, 48>(&in[48], &in[96]), opt);
+    optional<fp> c0 = fp::fromBytesLE(span<const uint8_t, 48>(&in[ 0], 48), opt);
+    optional<fp> c1 = fp::fromBytesLE(span<const uint8_t, 48>(&in[48], 48), opt);
     if(!c1 || !c0) return {};
     return fp2({*c0, *c1});
 }
@@ -827,18 +827,18 @@ fp6::fp6(const fp6& e) : c0(e.c0), c1(e.c1), c2(e.c2)
 
 optional<fp6> fp6::fromBytesBE(const span<const uint8_t, 288> in, const conv_opt opt)
 {
-    optional<fp2> c2 = fp2::fromBytesBE(span<const uint8_t, 96>(&in[  0], &in[ 96]), opt);
-    optional<fp2> c1 = fp2::fromBytesBE(span<const uint8_t, 96>(&in[ 96], &in[192]), opt);
-    optional<fp2> c0 = fp2::fromBytesBE(span<const uint8_t, 96>(&in[192], &in[288]), opt);
+    optional<fp2> c2 = fp2::fromBytesBE(span<const uint8_t, 96>(&in[  0], 96), opt);
+    optional<fp2> c1 = fp2::fromBytesBE(span<const uint8_t, 96>(&in[ 96], 96), opt);
+    optional<fp2> c0 = fp2::fromBytesBE(span<const uint8_t, 96>(&in[192], 96), opt);
     if(!c2 || !c1 || !c0) return {};
     return fp6({*c0, *c1, *c2});
 }
 
 optional<fp6> fp6::fromBytesLE(const span<const uint8_t, 288> in, const conv_opt opt)
 {
-    optional<fp2> c0 = fp2::fromBytesLE(span<const uint8_t, 96>(&in[  0], &in[ 96]), opt);
-    optional<fp2> c1 = fp2::fromBytesLE(span<const uint8_t, 96>(&in[ 96], &in[192]), opt);
-    optional<fp2> c2 = fp2::fromBytesLE(span<const uint8_t, 96>(&in[192], &in[288]), opt);
+    optional<fp2> c0 = fp2::fromBytesLE(span<const uint8_t, 96>(&in[  0], 96), opt);
+    optional<fp2> c1 = fp2::fromBytesLE(span<const uint8_t, 96>(&in[ 96], 96), opt);
+    optional<fp2> c2 = fp2::fromBytesLE(span<const uint8_t, 96>(&in[192], 96), opt);
     if(!c2 || !c1 || !c0) return {};
     return fp6({*c0, *c1, *c2});
 }
@@ -1240,16 +1240,16 @@ fp12::fp12(const fp12& e) : c0(e.c0), c1(e.c1)
 
 optional<fp12> fp12::fromBytesBE(const span<const uint8_t, 576> in, const conv_opt opt)
 {
-    optional<fp6> c1 = fp6::fromBytesBE(span<const uint8_t, 288>(&in[  0], &in[288]), opt);
-    optional<fp6> c0 = fp6::fromBytesBE(span<const uint8_t, 288>(&in[288], &in[576]), opt);
+    optional<fp6> c1 = fp6::fromBytesBE(span<const uint8_t, 288>(&in[  0], 288), opt);
+    optional<fp6> c0 = fp6::fromBytesBE(span<const uint8_t, 288>(&in[288], 288), opt);
     if(!c1 || !c0) return {};
     return fp12({*c0, *c1});
 }
 
 optional<fp12> fp12::fromBytesLE(const span<const uint8_t, 576> in, const conv_opt opt)
 {
-    optional<fp6> c0 = fp6::fromBytesLE(span<const uint8_t, 288>(&in[  0], &in[288]), opt);
-    optional<fp6> c1 = fp6::fromBytesLE(span<const uint8_t, 288>(&in[288], &in[576]), opt);
+    optional<fp6> c0 = fp6::fromBytesLE(span<const uint8_t, 288>(&in[  0], 288), opt);
+    optional<fp6> c1 = fp6::fromBytesLE(span<const uint8_t, 288>(&in[288], 288), opt);
     if(!c1 || !c0) return {};
     return fp12({*c0, *c1});
 }

--- a/src/g.cpp
+++ b/src/g.cpp
@@ -22,9 +22,9 @@ optional<g1> g1::fromJacobianBytesBE(const span<const uint8_t, 144> in, conv_opt
     // We decided to always validate the input here. Check flag will only affect on-curve checks.
     bool curve_check = opt.check_valid;
     opt.check_valid = true;
-    optional<fp> x = fp::fromBytesBE(span<const uint8_t, 48>(&in[ 0], &in[ 48]), opt);
-    optional<fp> y = fp::fromBytesBE(span<const uint8_t, 48>(&in[48], &in[ 96]), opt);
-    optional<fp> z = fp::fromBytesBE(span<const uint8_t, 48>(&in[96], &in[144]), opt);
+    optional<fp> x = fp::fromBytesBE(span<const uint8_t, 48>(&in[ 0], 48), opt);
+    optional<fp> y = fp::fromBytesBE(span<const uint8_t, 48>(&in[48], 48), opt);
+    optional<fp> z = fp::fromBytesBE(span<const uint8_t, 48>(&in[96], 48), opt);
     if(!x || !y || !z) return {};
     g1 p = g1({*x, *y, *z});
     if(curve_check && !p.isOnCurve())
@@ -39,9 +39,9 @@ optional<g1> g1::fromJacobianBytesLE(const span<const uint8_t, 144> in, conv_opt
     // We decided to always validate the input here. Check flag will only affect on-curve checks.
     bool curve_check = opt.check_valid;
     opt.check_valid = true;
-    optional<fp> x = fp::fromBytesLE(span<const uint8_t, 48>(&in[ 0], &in[ 48]), opt);
-    optional<fp> y = fp::fromBytesLE(span<const uint8_t, 48>(&in[48], &in[ 96]), opt);
-    optional<fp> z = fp::fromBytesLE(span<const uint8_t, 48>(&in[96], &in[144]), opt);
+    optional<fp> x = fp::fromBytesLE(span<const uint8_t, 48>(&in[ 0], 48), opt);
+    optional<fp> y = fp::fromBytesLE(span<const uint8_t, 48>(&in[48], 48), opt);
+    optional<fp> z = fp::fromBytesLE(span<const uint8_t, 48>(&in[96], 48), opt);
     if(!x || !y || !z) return {};
     g1 p = g1({*x, *y, *z});
     if(curve_check && !p.isOnCurve())
@@ -56,8 +56,8 @@ optional<g1> g1::fromAffineBytesBE(const span<const uint8_t, 96> in, conv_opt op
     // We decided to always validate the input here. Check flag will only affect on-curve checks.
     bool curve_check = opt.check_valid;
     opt.check_valid = true;
-    optional<fp> x = fp::fromBytesBE(span<const uint8_t, 48>(&in[ 0], &in[ 48]), opt);
-    optional<fp> y = fp::fromBytesBE(span<const uint8_t, 48>(&in[48], &in[ 96]), opt);
+    optional<fp> x = fp::fromBytesBE(span<const uint8_t, 48>(&in[ 0], 48), opt);
+    optional<fp> y = fp::fromBytesBE(span<const uint8_t, 48>(&in[48], 48), opt);
     if(!x || !y) return {};
     // check if given input points to infinity
     if(x->isZero() && y->isZero())
@@ -78,8 +78,8 @@ optional<g1> g1::fromAffineBytesLE(const span<const uint8_t, 96> in, conv_opt op
     // We decided to always validate the input here. Check flag will only affect on-curve checks.
     bool curve_check = opt.check_valid;
     opt.check_valid = true;
-    optional<fp> x = fp::fromBytesLE(span<const uint8_t, 48>(&in[ 0], &in[ 48]), opt);
-    optional<fp> y = fp::fromBytesLE(span<const uint8_t, 48>(&in[48], &in[ 96]), opt);
+    optional<fp> x = fp::fromBytesLE(span<const uint8_t, 48>(&in[ 0], 48), opt);
+    optional<fp> y = fp::fromBytesLE(span<const uint8_t, 48>(&in[48], 48), opt);
     if(!x || !y) return {};
     // check if given input points to infinity
     if(x->isZero() && y->isZero())
@@ -735,9 +735,9 @@ optional<g2> g2::fromJacobianBytesBE(const span<const uint8_t, 288> in, conv_opt
     // We decided to always validate the input here. Check flag will only affect on-curve checks.
     bool curve_check = opt.check_valid;
     opt.check_valid = true;
-    optional<fp2> x = fp2::fromBytesBE(span<const uint8_t, 96>(&in[  0], &in[ 96]), opt);
-    optional<fp2> y = fp2::fromBytesBE(span<const uint8_t, 96>(&in[ 96], &in[192]), opt);
-    optional<fp2> z = fp2::fromBytesBE(span<const uint8_t, 96>(&in[192], &in[288]), opt);
+    optional<fp2> x = fp2::fromBytesBE(span<const uint8_t, 96>(&in[  0], 96), opt);
+    optional<fp2> y = fp2::fromBytesBE(span<const uint8_t, 96>(&in[ 96], 96), opt);
+    optional<fp2> z = fp2::fromBytesBE(span<const uint8_t, 96>(&in[192], 96), opt);
     if(!x || !y || !z) return {};
     g2 p = g2({*x, *y, *z});
     if(curve_check && !p.isOnCurve())
@@ -752,9 +752,9 @@ optional<g2> g2::fromJacobianBytesLE(const span<const uint8_t, 288> in, conv_opt
     // We decided to always validate the input here. Check flag will only affect on-curve checks.
     bool curve_check = opt.check_valid;
     opt.check_valid = true;
-    optional<fp2> x = fp2::fromBytesLE(span<const uint8_t, 96>(&in[  0], &in[ 96]), opt);
-    optional<fp2> y = fp2::fromBytesLE(span<const uint8_t, 96>(&in[ 96], &in[192]), opt);
-    optional<fp2> z = fp2::fromBytesLE(span<const uint8_t, 96>(&in[192], &in[288]), opt);
+    optional<fp2> x = fp2::fromBytesLE(span<const uint8_t, 96>(&in[  0], 96), opt);
+    optional<fp2> y = fp2::fromBytesLE(span<const uint8_t, 96>(&in[ 96], 96), opt);
+    optional<fp2> z = fp2::fromBytesLE(span<const uint8_t, 96>(&in[192], 96), opt);
     if(!x || !y || !z) return {};
     g2 p = g2({*x, *y, *z});
     if(curve_check && !p.isOnCurve())
@@ -769,8 +769,8 @@ optional<g2> g2::fromAffineBytesBE(const span<const uint8_t, 192> in, conv_opt o
     // We decided to always validate the input here. Check flag will only affect on-curve checks.
     bool curve_check = opt.check_valid;
     opt.check_valid = true;
-    optional<fp2> x = fp2::fromBytesBE(span<const uint8_t, 96>(&in[  0], &in[ 96]), opt);
-    optional<fp2> y = fp2::fromBytesBE(span<const uint8_t, 96>(&in[ 96], &in[192]), opt);
+    optional<fp2> x = fp2::fromBytesBE(span<const uint8_t, 96>(&in[  0], 96), opt);
+    optional<fp2> y = fp2::fromBytesBE(span<const uint8_t, 96>(&in[ 96], 96), opt);
     if(!x || !y) return {};
     // check if given input points to infinity
     if(x->isZero() && y->isZero())
@@ -791,8 +791,8 @@ optional<g2> g2::fromAffineBytesLE(const span<const uint8_t, 192> in, conv_opt o
     // We decided to always validate the input here. Check flag will only affect on-curve checks.
     bool curve_check = opt.check_valid;
     opt.check_valid = true;
-    optional<fp2> x = fp2::fromBytesLE(span<const uint8_t, 96>(&in[  0], &in[ 96]), opt);
-    optional<fp2> y = fp2::fromBytesLE(span<const uint8_t, 96>(&in[ 96], &in[192]), opt);
+    optional<fp2> x = fp2::fromBytesLE(span<const uint8_t, 96>(&in[  0], 96), opt);
+    optional<fp2> y = fp2::fromBytesLE(span<const uint8_t, 96>(&in[ 96], 96), opt);
     if(!x || !y) return {};
     // check if given input points to infinity
     if(x->isZero() && y->isZero())
@@ -823,8 +823,8 @@ optional<g2> g2::fromCompressedBytesBE(const span<const uint8_t, 96> in)
     // reconstruct point from x coordinate
     bool ysign = ((in[0] >> 5) & 1) == 1;
     g2 p;
-    scalar::fromBytesBE(span<const uint8_t, 48>(&in[0], &in[48]), p.x.c1.d);
-    auto c0 = fp::fromBytesBE(span<const uint8_t, 48>(&in[48], &in[96]));
+    scalar::fromBytesBE(span<const uint8_t, 48>(&in[0], 48), p.x.c1.d);
+    auto c0 = fp::fromBytesBE(span<const uint8_t, 48>(&in[48], 48));
     if (!c0) {
         return {};
     }


### PR DESCRIPTION
Cleanup use of `span` constructor. Use `span` constructor that takes a begin iterator and length instead of begin/end. The subscript operator call is not needed, these are all fixed sized spans that can be created with a hard-coded length. Also I think it makes the code easier to read and easier to verify correctness.